### PR TITLE
Fix optionally missing album and id keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# pycharm
+.idea/
 *.pyo
 *.pyc
 .DS_Store

--- a/addon.xml
+++ b/addon.xml
@@ -1,26 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.audio.spotify" version="1.2.3" name="Spotify" provider-name="GLK">
+<addon id="plugin.audio.spotify" version="1.2.0" name="Spotify" provider-name="glk1001">
     <requires>
-        <import addon="xbmc.python" version="3.0.1"/>
-        <import addon="xbmc.addon" version="19.90.101"/>
+        <import addon="xbmc.python" version="3.0.0"/>
+        <import addon="xbmc.addon" version="18.9.701"/>
         <import addon="script.module.requests" version="2.22.0"/>
         <import addon="script.module.simplejson" version="3.17.0"/>
         <import addon="script.module.simplecache" version="2.0.0"/>
-	<import addon="script.module.six" version="1.14.0"/>
+        <import addon="script.module.six" version="1.14.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="plugin.py">
         <provides>audio</provides>
     </extension>
-	<extension library="service.py" point="xbmc.service" />
+    <extension library="service.py" point="xbmc.service" />
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
         <summary lang="en_GB">Unofficial Spotify music plugin for Kodi</summary>
         <description lang="en_GB">Requires a Spotify premium account.</description>
-        <disclaimer lang="en_GB">
-            This product uses SPOTIFY(R) CORE but is not endorsed,
-            certified or otherwise approved in any way by Spotify.
-            Spotify is the registered trade mark of the Spotify Group.
-        </disclaimer>
+        <disclaimer lang="en_GB">This product uses the SPOTIFY WEB API but is not endorsed, certified or otherwise approved in any way by Spotify. Spotify is the registered trade mark of Spotify AB.</disclaimer>
+        <source>https://github.com/glk1001/plugin.audio.spotify</source>
+        <news>v1.2.0 (2022-07-17)
+            [new] The Unofficial Spotify for Kodi add-on by Marcelveldt is now working for Kodi 19 and 20.
+                  Thanks to Ldsz, Elkropac, and FernetMenta for getting it to work with Python 3.9. Code
+                  cleanup and general add-on cleaning by Glk1001. Tested and working with Kodi 19 and 20
+                  on Ubuntu 21.10.
+            [issue] Does not work with Python 3.10 (and therefore Ubuntu 22.04) - problem with 3.10 and sqlite3.
+        </news>
         <assets>
             <icon>resources/icon.png</icon>
             <fanart>resources/fanart.jpg</fanart>

--- a/addon.xml
+++ b/addon.xml
@@ -18,12 +18,10 @@
         <description lang="en_GB">Requires a Spotify premium account.</description>
         <disclaimer lang="en_GB">This product uses the SPOTIFY WEB API but is not endorsed, certified or otherwise approved in any way by Spotify. Spotify is the registered trade mark of Spotify AB.</disclaimer>
         <source>https://github.com/glk1001/plugin.audio.spotify</source>
+        <website>https://github.com/glk1001/glk1001.github.io</website>
         <news>v1.2.0 (2022-07-17)
-            [new] The Unofficial Spotify for Kodi add-on by Marcelveldt is now working for Kodi 19 and 20.
-                  Thanks to Ldsz, Elkropac, and FernetMenta for getting it to work with Python 3.9. Code
-                  cleanup and general add-on cleaning by Glk1001. Tested and working with Kodi 19 and 20
-                  on Ubuntu 21.10.
-            [issue] Does not work with Python 3.10 (and therefore Ubuntu 22.04) - problem with 3.10 and sqlite3.
+        - [new] The Unofficial Spotify for Kodi add-on by Marcelveldt is now working for Kodi 19 and 20. Thanks to Ldsz, Elkropac, and FernetMenta for getting it to work with Python 3.9. Code cleanup and general add-on cleaning by Glk1001. Tested and working with Kodi 19 and 20 on Ubuntu 21.10.
+        - [issue] Does not work with Python 3.10 (and therefore Ubuntu 22.04) - problem with 3.10 and sqlite3.
         </news>
         <assets>
             <icon>resources/icon.png</icon>

--- a/addon.xml
+++ b/addon.xml
@@ -15,7 +15,7 @@
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
         <summary lang="en_GB">Unofficial Spotify music plugin for Kodi</summary>
-        <description lang="en_GB">Requires a Spotify premium account.</description>
+        <description lang="en_GB">Allows you to use your Spotify premium account to connect and play Spotify through Kodi. After installing, use 'Configure' to enter your Spotify username and password.</description>
         <disclaimer lang="en_GB">This product uses the SPOTIFY WEB API but is not endorsed, certified or otherwise approved in any way by Spotify. Spotify is the registered trade mark of Spotify AB.</disclaimer>
         <source>https://github.com/glk1001/plugin.audio.spotify</source>
         <website>https://github.com/glk1001/glk1001.github.io</website>

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -267,3 +267,7 @@ msgstr "Lokale Wiedergabe mit entferntem Host %s"
 msgctxt "#11064"
 msgid "Use Kodi OSD for playback on (remote) Spotify Connect device"
 msgstr "Benutze Kodi OSD für Wiedergabe auf (entferntem) Spotify Connect Gerät"
+
+msgctxt "#11068"
+msgid "Initial Spotify volume (%)"
+msgstr "Initial Spotify volume (%)"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -283,3 +283,7 @@ msgstr ""
 msgctxt "#11067"
 msgid "Are you sure you want to logoff ?"
 msgstr ""
+
+msgctxt "#11068"
+msgid "Initial Spotify volume as a percent (disable with -1)"
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -155,3 +155,7 @@ msgstr "Liste de chansons comme vue par défaut"
 msgctxt "#11035"
 msgid "Play song radio"
 msgstr "Jouer la radio"
+
+msgctxt "#11068"
+msgid "Initial Spotify volume (%)"
+msgstr "Initial Spotify volume (%)"

--- a/resources/language/resource.language.he_he/strings.po
+++ b/resources/language/resource.language.he_he/strings.po
@@ -275,3 +275,7 @@ msgstr "ניגון מקומי באמצעות מארח מרוחק %s"
 msgctxt "#11064"
 msgid "Use Kodi OSD for playback on (remote) Spotify Connect device"
 msgstr "תשתמש בנגן של קודי כהתקן הפעלה (מרוחק) כאשר Spotify מתחברת"
+
+msgctxt "#11068"
+msgid "Initial Spotify volume (%)"
+msgstr "Initial Spotify volume (%)"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -249,3 +249,7 @@ msgstr "UItloggen?"
 msgctxt "#11067"
 msgid "Are you sure you want to logoff ?"
 msgstr "Weet je zeker dat je wilt uitloggen?"
+
+msgctxt "#11068"
+msgid "Initial Spotify volume (%)"
+msgstr "Initial Spotify volume (%)"

--- a/resources/lib/plugin_content.py
+++ b/resources/lib/plugin_content.py
@@ -973,14 +973,14 @@ class PluginContent:
                 track["album"] = albumdetails
             if track.get("images"):
                 thumb = track["images"][0]['url']
-            elif track['album'].get("images"):
+            elif track.get('album',{}).get("images"):
                 thumb = track['album']["images"][0]['url']
             else:
                 thumb = "DefaultMusicSongs.png"
             track['thumb'] = thumb
 
             # skip local tracks in playlists
-            if not track['id']:
+            if not track.get('id'):
                 continue
 
             artists = []

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -19,13 +19,17 @@
         <setting id="username5" type="text" label="11046" default="" visible="eq(-13,true)"/>
         <setting id="password5" type="text" option="hidden" label="11002" default="" visible="eq(-14,true)"/>
 	</category>
-    
+
     <category label="11054" visible="!IsEmpty(Window(Home).Property(spotify.supportsplayback))">
         <setting id="connect_player" type="bool" label="11036" default="true" visible="!IsEmpty(Window(Home).Property(spotify.supportsplayback))"/>
         <setting type="sep" />
+        <setting id="initial_volume" type="number" label="11068" help="" default="-1">
+            <minimum>-1</minimum>
+            <maximum>100</maximum>
+        </setting>
         <setting type="lsep" label="11059" />
     </category>
-    
+
     <category label="11055">
         <setting id="categoryDefaultView" type="text" label="11020" default=""/>
         <setting id="playlistDefaultView" type="text" label="11031" default=""/>
@@ -36,6 +40,5 @@
         <setting id="prefer_kodi_osd" type="bool" label="11064" default="false"/>
         <setting type="sep" />
         <setting id="appendArtistToTitle" type="bool" label="11030" default="false"/>
-	</category>
-    
+    </category>
 </settings>


### PR DESCRIPTION
I run into an issue with playing playlists.

I guess the issue comes from the greyed-out items. Those are not local items but are no longer available on Spotify.

<img width="1256" alt="Képernyőfotó 2022-08-04 - 23 00 55" src="https://user-images.githubusercontent.com/126671/182952040-f4507c19-51a5-48d1-b6d7-83098307df0b.png">

